### PR TITLE
Fix reference error `props is not defined`

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -63,7 +63,7 @@ export default class extends React.Component {
     }
 
     componentWillReceiveProps = (nextProps) => {
-        this.init(props);
+        this.init(this.props);
         this.setState(this.state);
     }
 


### PR DESCRIPTION
Throws a runtime error when the component updates because props is not defined.
