### PR TITLE
Remove react from bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:8.1.2-slim
 MAINTAINER mac <mac.gainor@gmail.com>
 
 # install the node modules at container build time

--- a/README.md
+++ b/README.md
@@ -149,3 +149,4 @@ I'm also inspired by users who come up with interesting feature requests.  Reach
 ### To-Do's
 1. Improve documentation for `onAdd` and `onDelete` props
 2. Improve style organization
+3. Continue size analysis and remove larger dependencies from build where possible.

--- a/entrypoints/coverage.sh
+++ b/entrypoints/coverage.sh
@@ -3,6 +3,9 @@ echo Running Coverage Report
 
 cd /react
 
+echo Installing Test Dependencies
+sh ./entrypoints/install-test-dependencies.sh
+
 echo Running: npm run unit_test
 npm run test:unit
 

--- a/entrypoints/debug.sh
+++ b/entrypoints/debug.sh
@@ -2,6 +2,9 @@
 
 cd /react
 
+echo Installing Test Dependencies
+sh ./entrypoints/install-test-dependencies.sh
+
 echo getting source tree..
 npm run modules:tree > debug/tree.json
 

--- a/entrypoints/install-test-dependencies.sh
+++ b/entrypoints/install-test-dependencies.sh
@@ -1,0 +1,14 @@
+npm install --silent \
+    react@15.5.4 \
+    react-dom@15.5.4  \
+    chai@3.5.0 \
+    coveralls@2.13.1 \
+    enzyme@2.8.2 \
+    ignore-styles@5.0.1 \
+    istanbul@0.4.5 \
+    jsdom@10.1.0 \
+    mocha@3.2.0 \
+    nyc@10.3.2 \
+    react-test-renderer@15.5.4 \
+    sinon@2.2.0 \
+    webpack-bundle-size-analyzer@2.7.0

--- a/entrypoints/test.sh
+++ b/entrypoints/test.sh
@@ -3,4 +3,7 @@ echo Running Tests
 
 cd /react
 
+echo Installing Test Dependencies
+sh ./entrypoints/install-test-dependencies.sh
+
 exec npm run test:unit

--- a/entrypoints/test_watch.sh
+++ b/entrypoints/test_watch.sh
@@ -2,4 +2,7 @@
 echo Running Tests
 cd /react
 
+echo Installing Test Dependencies
+sh ./entrypoints/install-test-dependencies.sh
+
 exec npm run test:watch

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-json-view",
   "description": "Interactive react component for displaying javascript arrays and JSON objects.",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "main": "dist/main.js",
   "files": [
     "dist/"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,14 @@
   "files": [
     "dist/"
   ],
+  "dependencies": {
+    "clipboard": "^1.6.1",
+    "flux": "^3.1.2",
+    "radium":"^0.19.1",
+    "react-base16-styling": "^0.5.3",
+    "react-icons": "2.2.5",
+    "react-tooltip": "^3.3.0"
+  },
   "devDependencies": {
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",
@@ -19,31 +27,26 @@
     "babel-preset-stage-0": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-register": "^6.24.1",
+    "html-webpack-plugin": "2.28.0",
+    "react-hot-loader": "^3.0.0-beta.6",
+    "webpack": "^2.2.1",
+    "webpack-dev-server": "^2.3.0"
+  },
+  "peerDependencies": {
     "chai": "^3.5.0",
-    "clipboard": "^1.6.1",
     "coveralls": "^2.13.1",
     "enzyme": "^2.8.2",
-    "flux": "^3.1.2",
-    "html-webpack-plugin": "2.28.0",
     "ignore-styles": "^5.0.1",
     "istanbul": "^0.4.5",
     "jsdom": "^10.1.0",
     "mocha": "^3.2.0",
     "nyc": "^10.3.2",
-    "radium":"^0.19.1",
     "react": "^15.5.4",
-    "react-base16-styling": "^0.5.3",
     "react-dom": "^15.5.4",
-    "react-hot-loader": "^3.0.0-beta.6",
-    "react-icons": "2.2.5",
     "react-test-renderer": "^15.5.4",
-    "react-tooltip": "^3.3.0",
     "sinon": "^2.2.0",
-    "webpack": "^2.2.1",
-    "webpack-bundle-size-analyzer": "^2.7.0",
-    "webpack-dev-server": "^2.3.0"
+    "webpack-bundle-size-analyzer": "^2.7.0"
   },
-  "dependencies": {},
   "scripts": {
     "build": "webpack -p --display-error-details --progress",
     "dev:hot": "webpack-dev-server",

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -15,6 +15,8 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/3.4.0/es5-shim.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/3.4.0/es5-sham.js"></script>
     <![endif]-->
+    <script src="https://unpkg.com/react@15/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@15/dist/react-dom.js"></script>
     <style>
       .react-json-view {
         padding: 4px 6px;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,8 +23,20 @@ const config = {
   entry: [entrypoint],
   externals: {
     'cheerio': 'window',
-    'react/lib/ExecutionEnvironment': true,
-    'react/lib/ReactContext': true,
+      react: {
+        root: 'React',
+        commonjs2: 'react',
+        commonjs: 'react',
+        amd: 'react',
+        umd: 'react',
+      },
+      'react-dom': {
+        root: 'ReactDOM',
+        commonjs2: 'react-dom',
+        commonjs: 'react-dom',
+        amd: 'react-dom',
+        umd: 'react-dom',
+      },
   },
   devServer: {
     host: '0.0.0.0',


### PR DESCRIPTION
# current bundle size analysis

radium: 63.25 KB (12.8%)
inline-style-prefixer: 56.87 KB (11.5%)
react-tooltip: 49.97 KB (10.1%)
babel-runtime: 39.75 KB (8.01%)
  core-js: 36.45 KB (91.7%)
  <self>: 3.29 KB (8.28%)
lodash.curry: 35.03 KB (7.06%)
base16: 22.03 KB (4.44%)
bowser: 17.29 KB (3.49%)
clipboard: 15.31 KB (3.09%)
lodash.flow: 11.37 KB (2.29%)
react-icons: 10.49 KB (2.11%)
react-base16-styling: 9.73 KB (1.96%)
events: 8.13 KB (1.64%)
flux: 7.46 KB (1.50%)
react-icon-base: 4.33 KB (0.872%)
  prop-types: 2.37 KB (54.9%)
  <self>: 1.95 KB (45.1%)
pure-color: 3.45 KB (0.696%)
good-listener: 3.37 KB (0.680%)
prop-types: 3.04 KB (0.612%)
fbjs: 2.65 KB (0.535%)
delegate: 1.82 KB (0.367%)
tiny-emitter: 1.53 KB (0.308%)
classnames: 1.08 KB (0.217%)
select: 1 KB (0.202%)
exenv: 863 B (0.170%)
webpack: 597 B (0.118%)
hyphenate-style-name: 339 B (0.0668%)
<self>: 125.23 KB (25.3%)
