### PR TITLE
Fixes #95 Correct current updated_src after an onEdit 

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -78,6 +78,15 @@ export default class extends React.Component {
         }
     }
 
+    componentDidUpdate() {
+        ObjectAttributes.set(
+            this.rjvId,
+            'global',
+            'src',
+            this.props.src
+        );
+    }
+
     init = (props) => {
         for (let i in this.defaults) {
             if (props[i] !== undefined) {

--- a/test/tests/js/components/VariableEditor-test.js
+++ b/test/tests/js/components/VariableEditor-test.js
@@ -121,6 +121,36 @@ describe('<VariableEditor />', function () {
         ).to.equal(0);
     });
 
+    it('VariableEditor edit after src change should respect current src', function () {
+        const oldSrc = {edited: true, other: 'old'};
+        const currentSrc = {edited: true, other: 'current'};
+
+        const wrapper = mount(
+            <Index
+                src={oldSrc}
+                theme='rjv-default'
+                onEdit={(edit) => {
+                    expect(edit.updated_src.other).to.equal(currentSrc.other);
+                    return true;
+                }}
+                rjvId={rjvId}
+            />
+        );
+        wrapper.setProps({src: currentSrc});
+
+        wrapper.find('.click-to-edit-icon').first().simulate('click');
+        expect(
+            wrapper.state('onEdit')
+        ).to.not.equal(false);
+        expect(
+            wrapper.find('.variable-editor').length
+        ).to.equal(1);
+        wrapper.find('.edit-check.string-value').simulate('click');
+        expect(
+            wrapper.find('.variable-editor').length
+        ).to.equal(0);
+    });
+
     it('VariableEditor detected null', function () {
         const wrapper = shallow(
             <VariableEditor


### PR DESCRIPTION
This PR fixes #95.

I'm not really sure why the props.src duplication in state and in ObjectAttributes is necessary, instead of just using the props.src directly. I'm also not sure if componentDidUpdate is the right place to update ObjectAttributes but at least it passes all tests. I have also added a test to ensure the fixed behavior.


