### PR TITLE
updated behavior rendering behavior for empty objects

### DIFF
--- a/dev-server/src/index.js
+++ b/dev-server/src/index.js
@@ -18,7 +18,7 @@ ReactDom.render(
         onEdit={(e)=>{console.log(e); if (e.new_value == 'error'){return false;}}}
         onDelete={(e)=>{console.log(e);}}
         onAdd={(e)=>{console.log(e); if (e.new_value == 'error'){return false;}}}
-        displayObjectSize={false}
+        displayObjectSize={true}
         enableClipboard={true} />
 
         <br />
@@ -123,6 +123,8 @@ function getExampleJson1() {
     return {
         string: 'this is a test string',
         integer: 42,
+        empty_array: [],
+        empty_object: {},
         array: [1, 2, 3, 'test'],
         float: -2.757,
         undefined_var: undefined,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-json-view",
   "description": "Interactive react component for displaying javascript arrays and JSON objects.",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "main": "dist/main.js",
   "files": [
     "dist/"

--- a/src/js/components/DataTypes/Object.js
+++ b/src/js/components/DataTypes/Object.js
@@ -101,6 +101,7 @@ class rjvObject extends React.Component {
         } else {
             return (
                 <div {...Theme(this.props.theme, 'ellipsis')}
+                class="node-ellipsis"
                 onClick={this.toggleCollapsed}>
                     ...
                 </div>

--- a/src/js/components/DataTypes/Object.js
+++ b/src/js/components/DataTypes/Object.js
@@ -37,10 +37,15 @@ class rjvObject extends React.Component {
     state = {}
 
     initializeState = (props) => {
+        const size = Object.keys(props.src).length;
         const expanded = (
-            props.collapsed === false
-            || (props.collapsed !== true
-            && props.collapsed > props.depth)
+            (
+                props.collapsed === false
+                || (props.collapsed !== true
+                && props.collapsed > props.depth)
+            )
+            //initialize closed if object has no items
+            && size !== 0
         );
         const state = {
             rjvId: props.rjvId,
@@ -55,7 +60,8 @@ class rjvObject extends React.Component {
             ),
             object_type: (props.type == 'array' ? 'array' : 'object'),
             parent_type: (props.type == 'array' ? 'array' : 'object'),
-            display_name: (props.name ? props.name : '')
+            display_name: (props.name ? props.name : ''),
+            size: size
         }
 
         return {...this.state, ...state};
@@ -87,17 +93,24 @@ class rjvObject extends React.Component {
     }
 
     getEllipsis = () => {
-        return (
-            <div {...Theme(this.props.theme, 'ellipsis')}
-            onClick={this.toggleCollapsed}>
-                ...
-            </div>
-        );
+        const {size} = this.state;
+
+        if (size === 0) {
+            //don't render an ellipsis when an object has no items
+            return null
+        } else {
+            return (
+                <div {...Theme(this.props.theme, 'ellipsis')}
+                onClick={this.toggleCollapsed}>
+                    ...
+                </div>
+            )
+        }
     }
 
     getObjectMetaData = (src) => {
-        const size = Object.keys(src).length;
         const {rjvId, theme} = this.props;
+        const {size} = this.state;
         return (
             <VariableMeta size={size} {...this.props}/>
         );

--- a/test/tests/js/components/DataTypes/Object-test.js
+++ b/test/tests/js/components/DataTypes/Object-test.js
@@ -10,7 +10,7 @@ describe('<JsonObject />', function () {
 
     it('Object component should have a data type label', function () {
         let src = {
-            test: true
+            test: true,
         }
         const wrapper = shallow(
             <JsonObject
@@ -45,7 +45,9 @@ describe('<JsonObject />', function () {
             ],
             obj: {
                 test: true      //should have label
-            }
+            },
+            empty_arr: [],
+            empty_obj: {}
         }
         const wrapper = render(
             <JsonObject
@@ -242,6 +244,86 @@ describe('<JsonObject />', function () {
                 expect(
             wrapper.find('.collapsed-icon')
         ).to.have.length(1);
+    });
+
+    it('non-empty object should be expanded', function () {
+        let src = {test:true}
+
+        const wrapper = shallow(
+            <JsonObject
+            src={src}
+            namespace={['root']}
+            rjvId={rjvId}
+            theme='rjv-default'
+            indentWidth={1}
+            depth={1}
+            displayDataTypes={true}
+            type='object'
+            collapsed={false} />
+        );
+        expect(
+            wrapper.state('expanded')
+        ).to.equal(true);
+    });
+
+    it('empty object should not be expanded', function () {
+        let src = {}
+
+        const wrapper = shallow(
+            <JsonObject
+            src={src}
+            namespace={['root']}
+            rjvId={rjvId}
+            theme='rjv-default'
+            indentWidth={1}
+            depth={1}
+            displayDataTypes={true}
+            type='object'
+            collapsed={false} />
+        );
+        expect(
+            wrapper.state('expanded')
+        ).to.equal(false);
+    });
+
+    it('non-empty array should be expanded', function () {
+        let src = [1,2,3]
+
+        const wrapper = shallow(
+            <JsonObject
+            src={src}
+            namespace={['root']}
+            rjvId={rjvId}
+            theme='rjv-default'
+            indentWidth={1}
+            depth={1}
+            displayDataTypes={true}
+            type='object'
+            collapsed={false} />
+        );
+        expect(
+            wrapper.state('expanded')
+        ).to.equal(true);
+    });
+
+    it('empty array should not be expanded', function () {
+        let src = []
+
+        const wrapper = shallow(
+            <JsonObject
+            src={src}
+            namespace={['root']}
+            rjvId={rjvId}
+            theme='rjv-default'
+            indentWidth={1}
+            depth={1}
+            displayDataTypes={true}
+            type='object'
+            collapsed={false} />
+        );
+        expect(
+            wrapper.state('expanded')
+        ).to.equal(false);
     });
 
 });

--- a/test/tests/js/components/DataTypes/Object-test.js
+++ b/test/tests/js/components/DataTypes/Object-test.js
@@ -241,7 +241,7 @@ describe('<JsonObject />', function () {
         expect(
             wrapper.find('.expanded-icon')
         ).to.have.length(0);
-                expect(
+        expect(
             wrapper.find('.collapsed-icon')
         ).to.have.length(1);
     });
@@ -253,12 +253,6 @@ describe('<JsonObject />', function () {
             <JsonObject
             src={src}
             namespace={['root']}
-            rjvId={rjvId}
-            theme='rjv-default'
-            indentWidth={1}
-            depth={1}
-            displayDataTypes={true}
-            type='object'
             collapsed={false} />
         );
         expect(
@@ -274,11 +268,6 @@ describe('<JsonObject />', function () {
             src={src}
             namespace={['root']}
             rjvId={rjvId}
-            theme='rjv-default'
-            indentWidth={1}
-            depth={1}
-            displayDataTypes={true}
-            type='object'
             collapsed={false} />
         );
         expect(
@@ -294,11 +283,6 @@ describe('<JsonObject />', function () {
             src={src}
             namespace={['root']}
             rjvId={rjvId}
-            theme='rjv-default'
-            indentWidth={1}
-            depth={1}
-            displayDataTypes={true}
-            type='object'
             collapsed={false} />
         );
         expect(
@@ -313,17 +297,43 @@ describe('<JsonObject />', function () {
             <JsonObject
             src={src}
             namespace={['root']}
-            rjvId={rjvId}
-            theme='rjv-default'
-            indentWidth={1}
-            depth={1}
-            displayDataTypes={true}
-            type='object'
             collapsed={false} />
         );
         expect(
             wrapper.state('expanded')
         ).to.equal(false);
+    });
+
+    it('non-empty array should have ellipsis', function () {
+        let src = [1,2,3]
+
+        const wrapper = render(
+            <JsonObject
+            src={src}
+            namespace={['root']}
+            rjvId={rjvId}
+            collapsed={true} />
+        );
+
+        expect(
+            wrapper.find('.node-ellipsis')
+        ).to.have.length(1);
+    });
+
+    it('empty array should not have ellipsis', function () {
+        let src = []
+
+        const wrapper = render(
+            <JsonObject
+            src={src}
+            namespace={['root']}
+            rjvId={rjvId}
+            collapsed={true} />
+        );
+
+        expect(
+            wrapper.find('.node-ellipsis')
+        ).to.have.length(0);
     });
 
 });


### PR DESCRIPTION
empty nodes will default to a collapsed state and ellipsis will not be rendered.