### PR TITLE
Fix peerDependency warning for React v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "webpack-bundle-size-analyzer": "^2.7.0"
   },
   "peerDependencies": {
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react": "^16.0.0 || ^15.5.4",
+    "react-dom": "^16.0.0 || ^15.5.4"
   },
   "scripts": {
     "build": "webpack --config /react/webpack/webpack.config.js -p --display-error-details --progress --optimize-minimize",


### PR DESCRIPTION
- Allows React 16 as a peer dependency