### PR TITLE
Lowercase true/false

### DIFF
--- a/src/js/components/DataTypes/Boolean.js
+++ b/src/js/components/DataTypes/Boolean.js
@@ -13,7 +13,7 @@ export default class extends React.Component {
 
         return <div {...Theme(props.theme, 'boolean')}>
             <DataTypeLabel type_name={type_name} {...props} />
-            {props.value ? "True" : "False"}
+            {props.value ? "true" : "false"}
         </div>;
     }
 


### PR DESCRIPTION
Followup to #128, this PR changes the boolean datatype to show:

```
true/false
```

instead of

```
True/False
```