### PR TITLE
Add a prepublishOnly script

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "test": "./docker/coverage.sh",
     "test:coverage": "nyc report --reporter=text-lcov | coveralls",
     "test:unit": "nyc --reporter=html --reporter=text-lcov --reporter=text mocha /react/test/**/*-test.js",
-    "test:watch": "nyc --reporter=html --reporter=text-lcov --reporter=text mocha -w /react/test/**/*-test.js"
+    "test:watch": "nyc --reporter=html --reporter=text-lcov --reporter=text mocha -w /react/test/**/*-test.js",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a `prepublishOnly` script that does a thing when `npm publish` is run, just before it actually publishes.