### PR TITLE
Support for grouping large arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Name|Type|Default|Description
 `indentWidth`|`integer`|4|Set the indent-width for nested objects
 `collapsed`|`boolean` or `integer`|`false`|When set to `true`, all nodes will be collapsed by default.  Use an integer value to collapse at a particular depth.
 `collapseStringsAfterLength`|`integer`|`false`|When an integer value is assigned, strings will be cut off at that length. Collapsed strings are followed by an ellipsis. String content can be expanded and collapsed by clicking on the string value.
+`groupArraysAfterLength`|`integer`|`100`|When an integer value is assigned, arrays will be displayed in groups by count of the value. Groups are displayed with brakcet notation and can be expanded and collapsed by clickong on the brackets. 
 `enableClipboard`|`boolean` or `(copy)=>{}`|`true`|When prop is not `false`, the user can copy objects and arrays to clipboard by clicking on the clipboard icon.  Copy callbacks are supported.
 `displayObjectSize`|`boolean`|`true`|When set to `true`, objects and arrays are labeled with size
 `displayDataTypes`|`boolean`|`true`|When set to `true`, data type labels prefix values
@@ -63,6 +64,7 @@ Name|Type|Default|Description
 * Object and array nodes display length
 * Object and array nodes support a "Copy to Clipboard" feature
 * String values can be truncated after a specified length
+* Arrays can be subgrouped after a specified length
 * Base-16 Theme Support
 * When `onEdit` is enabled:
    * Double-Click Edit Mode

--- a/dev-server/src/index.js
+++ b/dev-server/src/index.js
@@ -10,6 +10,7 @@ import JsonViewer from './../../src/js/index';
 //render 2 different examples of the react-json-view component
 ReactDom.render(
     <div>
+        
         {/* just pass in your JSON to the src attribute */}
         <JsonViewer
         style={{padding:'30px', backgroundColor: 'white'}}
@@ -59,7 +60,7 @@ ReactDom.render(
         name={'feature_set'}
         displayDataTypes={false}
         indentWidth={5}
-        />
+        /> 
 
         <br />
 
@@ -106,7 +107,17 @@ ReactDom.render(
           base0E: 'rgba(70, 70, 230, 1)',
           base0F: 'rgba(70, 70, 230, 1)'
         }}
+    /> 
+
+
+    <JsonViewer
+        theme="hopscotch"
+        collapsed={false}
+        name="large_array"
+        groupArraysAfterLength={50}
+        src={getExampleJson4()}
         />
+
 
 
     </div>,
@@ -196,6 +207,17 @@ function getExampleJson3() {
             }
         ]
     };
+}
+
+
+function getExampleJson4() {
+    const large_array = new Array(225).fill('this is a large array full of items')
+
+    large_array.push(getExampleArray())
+
+    large_array.push(new Array(75).fill(Math.random()))
+
+    return large_array
 }
 
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "dist/"
   ],
   "dependencies": {
-    "clipboard": "^1.7.1",
     "flux": "^3.1.3",
     "react-base16-styling": "^0.5.3",
     "react-textarea-autosize": "^5.1.0"

--- a/src/js/components/ArrayGroup.js
+++ b/src/js/components/ArrayGroup.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import Theme from './../themes/getStyle';
 
+import VariableMeta from './VariableMeta';
 import ObjectName from './ObjectName'
 import ObjectComponent from './DataTypes/Object'
 
 //icons
 import { CollapsedIcon, ExpandedIcon } from './ToggleIcons';
 
-//increment 1 with each nested object & array
-const DEPTH_INCREMENT = 1
 //single indent is 5px
 const SINGLE_INDENT = 5;
 
@@ -59,8 +58,13 @@ export default class extends React.Component {
                     {...Theme(theme, jsvRoot ? 'jsv-root' : 'objectKeyVal', {paddingLeft: object_padding_left})}
                 >
             <ObjectName {...this.props} />
+
+            <VariableMeta size={src.length} {...this.props}/>
             {[...Array(groups)].map((_, i) => 
-                <div key={i} class='object-key-val' {...Theme(theme, 'objectKeyVal', {paddingLeft: array_group_padding_left})} >
+                <div key={i} class='object-key-val' {...Theme(theme, 'objectKeyVal', {
+                    marginLeft: 6,
+                    paddingLeft: array_group_padding_left
+                    })} >
                 <span {...Theme(theme, 'brace-row')}>
 
                     <div class="icon-container" {...Theme(theme, 'icon-container')}

--- a/src/js/components/ArrayGroup.js
+++ b/src/js/components/ArrayGroup.js
@@ -59,7 +59,9 @@ export default class extends React.Component {
                 >
             <ObjectName {...this.props} />
 
-            <VariableMeta size={src.length} {...this.props}/>
+            <span>
+                <VariableMeta size={src.length} {...this.props}/>
+            </span>
             {[...Array(groups)].map((_, i) => 
                 <div key={i} class='object-key-val array-group' {...Theme(theme, 'objectKeyVal', {
                     marginLeft: 6,

--- a/src/js/components/ArrayGroup.js
+++ b/src/js/components/ArrayGroup.js
@@ -61,13 +61,13 @@ export default class extends React.Component {
 
             <VariableMeta size={src.length} {...this.props}/>
             {[...Array(groups)].map((_, i) => 
-                <div key={i} class='object-key-val' {...Theme(theme, 'objectKeyVal', {
+                <div key={i} class='object-key-val array-group' {...Theme(theme, 'objectKeyVal', {
                     marginLeft: 6,
                     paddingLeft: array_group_padding_left
                     })} >
                 <span {...Theme(theme, 'brace-row')}>
 
-                    <div class="icon-container" {...Theme(theme, 'icon-container')}
+                    <div class='icon-container' {...Theme(theme, 'icon-container')}
                          onClick={(e) => {this.toggleCollapsed(i)}}>
                         {this.getExpandedIcon(i)}
                     </div>
@@ -85,10 +85,10 @@ export default class extends React.Component {
                             theme={theme}
                             {...rest}
                         />
-                    :   <span {...Theme(theme, 'brace')}  onClick={(e) => {this.toggleCollapsed(i)}}>
+                    :   <span {...Theme(theme, 'brace')}  onClick={(e) => {this.toggleCollapsed(i)}} class='array-group-brace'>
                             [
                             <div {...Theme(theme, 'array-group-meta-data')} class='array-group-meta-data'>
-                                <span class="object-size"
+                                <span class='object-size'
                                 {...Theme(theme, 'object-size')}>
                                 {i * size}
                                 {' - '}

--- a/src/js/components/ArrayGroup.js
+++ b/src/js/components/ArrayGroup.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import Theme from './../themes/getStyle';
+
+import ObjectName from './ObjectName'
+import ObjectComponent from './DataTypes/Object'
+
+//icons
+import { CollapsedIcon, ExpandedIcon } from './ToggleIcons';
+
+//increment 1 with each nested object & array
+const DEPTH_INCREMENT = 1
+//single indent is 5px
+const SINGLE_INDENT = 5;
+
+export default class extends React.Component {
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            expanded: {}
+        }
+    }
+
+    toggleCollapsed = (i) => {
+        this.state.expanded[i] = !this.state.expanded[i]
+
+        this.setState(this.state);
+    }
+
+    getExpandedIcon(i) {
+        const { theme, iconStyle } = this.props
+
+        if (!!this.state.expanded[i]) {
+            return <ExpandedIcon {...{theme, iconStyle}}/>
+        } 
+
+        return <CollapsedIcon {...{theme, iconStyle}} />
+    }
+
+    render() {
+        const { 
+            src, groupArraysAfterLength, depth, 
+            name, theme, jsvRoot, namespace, parent_type,
+            ...rest
+        } = this.props
+
+        let expanded_icon, object_padding_left = 0;
+
+        const array_group_padding_left = this.props.indentWidth * SINGLE_INDENT
+
+        if (!jsvRoot) {
+            object_padding_left = this.props.indentWidth * SINGLE_INDENT;
+        }
+
+        const size = groupArraysAfterLength
+        const groups = Math.ceil(src.length / size)
+
+        return (<div class='object-key-val'
+                    {...Theme(theme, jsvRoot ? 'jsv-root' : 'objectKeyVal', {paddingLeft: object_padding_left})}
+                >
+            <ObjectName {...this.props} />
+            {[...Array(groups)].map((_, i) => 
+                <div key={i} class='object-key-val' {...Theme(theme, 'objectKeyVal', {paddingLeft: array_group_padding_left})} >
+                <span {...Theme(theme, 'brace-row')}>
+
+                    <div class="icon-container" {...Theme(theme, 'icon-container')}
+                         onClick={(e) => {this.toggleCollapsed(i)}}>
+                        {this.getExpandedIcon(i)}
+                    </div>
+                    {!!this.state.expanded[i] ? 
+                        <ObjectComponent key={name + i}
+                            depth={0}
+                            name={false}
+                            collapsed={false}
+                            groupArraysAfterLength={size}
+                            index_offset={i * size}
+                            src={src.slice(i * size, i * size + size)}
+                            namespace={namespace}
+                            type="array"
+                            parent_type="array_group"
+                            theme={theme}
+                            {...rest}
+                        />
+                    :   <span {...Theme(theme, 'brace')}  onClick={(e) => {this.toggleCollapsed(i)}}>
+                            [
+                            <div {...Theme(theme, 'array-group-meta-data')} class='array-group-meta-data'>
+                                <span class="object-size"
+                                {...Theme(theme, 'object-size')}>
+                                {i * size}
+                                {' - '}
+                                {i * size + size > src.length ? src.length : i * size + size}
+                                </span>
+                            </div>
+                            ]
+                        </span>
+                    }
+                    
+                </span>
+                </div>
+            )}
+            </div>
+        );
+    }
+
+}

--- a/src/js/components/JsonViewer.js
+++ b/src/js/components/JsonViewer.js
@@ -1,14 +1,21 @@
 import React from "react";
 import JsonObject from './DataTypes/Object';
+import ArrayGroup from './ArrayGroup';
 
 export default class extends React.Component {
     render = () => {
         const {props} = this;
         const namespace = [props.name];
+        let ObjectComponent = JsonObject
+
+        if (props.groupArraysAfterLength && props.src.length > props.groupArraysAfterLength) {
+            ObjectComponent = ArrayGroup
+        }
+
         return (
             <div class="pretty-json-container object-container" >
                 <div class="object-content">
-                    <JsonObject
+                    <ObjectComponent
                     namespace={namespace}
                     depth={0}
                     jsvRoot={true}

--- a/src/js/components/ObjectName.js
+++ b/src/js/components/ObjectName.js
@@ -1,3 +1,4 @@
+import React from "react";
 import Theme from './../themes/getStyle';
 
 export default function getObjectName(props) {

--- a/src/js/components/ObjectName.js
+++ b/src/js/components/ObjectName.js
@@ -1,0 +1,31 @@
+import Theme from './../themes/getStyle';
+
+export default function getObjectName(props) {
+    const {
+        parent_type, namespace, theme, jsvRoot, name
+    } = props;
+
+    const display_name = props.name ? props.name : '';
+
+    if (jsvRoot && (name === false || name === null)) {
+        return (<span />);
+    } else if (parent_type == 'array') {
+        return (
+            <span {...Theme(theme, 'array-key')} key={namespace}>
+                <span class="array-key">{display_name}</span>
+                <span {...Theme(theme, 'colon')}>:</span>
+            </span>
+        );
+    } else {
+        return (
+            <span {...Theme(theme, 'object-name')} key={namespace}>
+                <span class="object-key">
+                    <span style={{verticalAlign:'top'}}>"</span>
+                    <span>{display_name}</span>
+                    <span style={{verticalAlign:'top'}}>"</span>
+                </span>
+                <span {...Theme(theme, 'colon')}>:</span>
+            </span>
+        );
+    }
+}

--- a/src/js/components/ToggleIcons.js
+++ b/src/js/components/ToggleIcons.js
@@ -1,0 +1,51 @@
+
+import Theme from './../themes/getStyle';
+
+import {
+    CircleMinus, CirclePlus,
+    SquareMinus, SquarePlus,
+    ArrowRight, ArrowDown
+} from './icons';
+
+export function ExpandedIcon(props) {
+    const {theme, iconStyle} = props;
+    switch (iconStyle) {
+        case "triangle":
+            return <ArrowDown
+                {...Theme(theme, 'expanded-icon')}
+                class="expanded-icon"
+            />
+        case "square":
+            return <SquareMinus
+                {...Theme(theme, 'expanded-icon')}
+                class="expanded-icon"
+            />
+        default:
+            return <CircleMinus
+                {...Theme(theme, 'expanded-icon')}
+                class="expanded-icon"
+            />
+    }
+}
+
+export function CollapsedIcon(props) {
+    const {theme, iconStyle} = props;
+    switch (iconStyle) {
+        case "triangle":
+            return <ArrowRight
+                {...Theme(theme, 'collapsed-icon')}
+                class="collapsed-icon"
+            />
+        case "square":
+            return <SquarePlus
+                {...Theme(theme, 'collapsed-icon')}
+                class="collapsed-icon"
+            />
+        default:
+            return <CirclePlus
+                {...Theme(theme, 'collapsed-icon')}
+                class="collapsed-icon"
+            />
+    }
+}
+

--- a/src/js/components/ToggleIcons.js
+++ b/src/js/components/ToggleIcons.js
@@ -1,4 +1,4 @@
-
+import React from "react";
 import Theme from './../themes/getStyle';
 
 import {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -41,7 +41,7 @@ export default class extends React.Component {
         theme: 'rjv-default',
         collapsed: false,
         collapseStringsAfterLength: false,
-        groupArraysAfterLength: false,
+        groupArraysAfterLength: 100,
         indentWidth: 4,
         enableClipboard: true,
         displayObjectSize: true,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -41,6 +41,7 @@ export default class extends React.Component {
         theme: 'rjv-default',
         collapsed: false,
         collapseStringsAfterLength: false,
+        groupArraysAfterLength: false,
         indentWidth: 4,
         enableClipboard: true,
         displayObjectSize: true,

--- a/src/js/themes/getStyle.js
+++ b/src/js/themes/getStyle.js
@@ -212,6 +212,10 @@ const getDefaultThemeStyling = theme => {
             marginRight: constants.iconMarginRight,
             verticalAlign: 'top',
         },
+        'array-group-meta-data': {
+            display: 'inline-block',
+            padding: constants.arrayGroupMetaPadding
+        },
         'object-meta-data': {
             display: 'inline-block',
             padding: constants.metaDataPadding

--- a/src/js/themes/getStyle.js
+++ b/src/js/themes/getStyle.js
@@ -141,7 +141,8 @@ const getDefaultThemeStyling = theme => {
             color: colors.objectSize,
             borderRadius: constants.objectSizeBorderRadius,
             fontStyle: constants.objectSizeFontStyle,
-            margin: constants.objectSizeMargin
+            margin: constants.objectSizeMargin,
+            cursor: 'default'
         },
         'data-type-label': {
             fontSize: constants.dataTypeFontSize,

--- a/src/js/themes/getStyle.js
+++ b/src/js/themes/getStyle.js
@@ -12,6 +12,7 @@ const colorMap = theme => ({
     arrayKeyColor: theme.base0C,
     objectSize: theme.base04,
     copyToClipboard: theme.base0F,
+    copyToClipboardCheck: theme.base0D,
     objectBorder: theme.base02,
     dataTypes: {
         boolean: theme.base0E,
@@ -212,6 +213,10 @@ const getDefaultThemeStyling = theme => {
             fontSize: constants.iconFontSize,
             marginRight: constants.iconMarginRight,
             verticalAlign: 'top',
+        },
+        'copy-icon-copied': {
+            color: colors.copyToClipboardCheck,
+            marginLeft: constants.clipboardCheckMarginLeft
         },
         'array-group-meta-data': {
             display: 'inline-block',

--- a/src/js/themes/styleConstants.js
+++ b/src/js/themes/styleConstants.js
@@ -64,6 +64,7 @@ export default {
   objectSizeMargin: '0px 6px 0px 0px',
 
   clipboardCursor: 'pointer',
+  clipboardCheckMarginLeft: '-12px',
 
   metaDataPadding: '0px 0px 0px 10px',
 

--- a/src/js/themes/styleConstants.js
+++ b/src/js/themes/styleConstants.js
@@ -67,6 +67,8 @@ export default {
 
   metaDataPadding: '0px 0px 0px 10px',
 
+  arrayGroupMetaPadding: '0px 0px 0px 4px',
+
   iconContainerWidth: '17px',
 
   tooltipPadding: '4px',

--- a/test/tests/js/Index-test.js
+++ b/test/tests/js/Index-test.js
@@ -125,4 +125,16 @@ describe('<Index />', function () {
         ).to.equal(true);
     });
 
+
+    it('index can have ArrayGroup root component', function() {
+        const wrapper = render(
+            <Index
+            name='test'
+            groupArraysAfterLength={5}
+            src={new Array(15).fill(0)}
+            />
+        );
+        expect(wrapper.find('.array-group')).to.have.length(3);
+    });
+
 });

--- a/test/tests/js/components/ArrayGroup-test.js
+++ b/test/tests/js/components/ArrayGroup-test.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, shallow, mount } from 'enzyme';
+import {expect} from 'chai';
+
+import ArrayGroup from '/react/src/js/components/ArrayGroup';
+import JsonObject from '/react/src/js/components/DataTypes/Object';
+import JsonString from '/react/src/js/components/DataTypes/String';
+
+describe('<ArrayGroup />', function () {
+    var large_array = new Array(15).fill('test');
+
+    it('ArrayGroup mount', function() {
+        const wrapper = render(
+            <ArrayGroup
+            groupArraysAfterLength={5}
+            namespace={'test'}
+            name='test'
+            src={large_array}
+            theme='rjv-default'
+            jsvRoot={false}/>
+        );
+
+        expect(
+            wrapper.find('.array-group').length
+        ).to.equal(3);
+    });
+
+    it('ArrayGroup expands and collapses', function() {
+        const wrapper = shallow(
+            <ArrayGroup
+            groupArraysAfterLength={5}
+            namespace={['test']}
+            name='test'
+            src={large_array}
+            theme='rjv-default'
+            jsvRoot={false}/>
+        );
+
+        wrapper.find('.array-group-brace').first().simulate('click');
+
+        expect(
+            wrapper.state().expanded[0]
+        ).to.equal(true);
+        
+        wrapper.find('.array-group').first().find('.icon-container').simulate('click');
+
+        expect(
+            wrapper.state().expanded[0]
+        ).to.equal(false);
+    })
+
+    it('ArrayGroup displays arrays on expansion', function() {
+        const wrapper = mount(
+            <ArrayGroup
+            groupArraysAfterLength={5}
+            namespace={['test']}
+            name='test'
+            src={large_array}
+            theme='rjv-default'
+            jsvRoot={false}/>
+        );
+
+        wrapper.setState({ expanded: { 0: true }});
+
+        expect(wrapper.find(JsonObject).length).to.equal(1);
+
+        expect(wrapper.find(JsonObject).find(JsonString).length).to.equal(5);
+    })
+
+    it('ArrayGroup paginates groups accurately', function() {
+        var test_array = new Array(17).fill('test');
+
+        const wrapper = mount(
+            <ArrayGroup
+            groupArraysAfterLength={5}
+            namespace={['test']}
+            name='test'
+            src={test_array}
+            theme='rjv-default'
+            jsvRoot={false}/>
+        );
+
+        expect(
+            wrapper.find('.array-group').length
+        ).to.equal(4);
+        
+        wrapper.setState({ expanded: { 3: true }});
+
+        expect(wrapper.find('.array-group').last().find(JsonString).length).to.equal(2);
+    });
+
+    it('ArrayGroup renders at root', function() {
+        const wrapper = render(
+            <ArrayGroup
+            groupArraysAfterLength={5}
+            namespace={['test']}
+            name='test'
+            src={large_array}
+            theme='rjv-default'
+            jsvRoot={true} />
+        );
+
+        expect(wrapper.find('.array-group').length).to.equal(3);
+    })
+});

--- a/test/tests/js/components/ObjectName-test.js
+++ b/test/tests/js/components/ObjectName-test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from 'enzyme';
+import {expect} from 'chai';
+
+import ObjectName from '/react/src/js/components/ObjectName';
+
+
+describe('<ObjectName />', function () {
+
+    it('ObjectName mount', function () {
+        
+        const wrapper = render(
+            <ObjectName
+            namespace={'test'}
+            name='test'
+            theme='rjv-default'
+            jsvRoot={false}/>
+        );
+        expect(wrapper.find('.object-key')).to.have.length(1);
+    });
+
+    it('ObjectName with parent array mount', function() {
+
+        const wrapper = render(
+            <ObjectName
+            namespace={'test'}
+            name='test'
+            parent_type='array'
+            theme='rjv-default'
+            jsvRoot={false}/>
+        );
+        expect(wrapper.find('.array-key')).to.have.length(1);
+    });
+
+    it('ObjectName at root without name', function() {
+        const wrapper = render(
+            <ObjectName
+            namespace={'test'}
+            name={false}
+            theme='rjv-default'
+            jsvRoot={true}/>
+        );
+        expect(wrapper.find('span').children()).to.have.length(0);
+    });
+})

--- a/test/tests/js/components/ToggleIcons-test.js
+++ b/test/tests/js/components/ToggleIcons-test.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, shallow } from 'enzyme';
+import {expect} from 'chai';
+
+import {ExpandedIcon, CollapsedIcon} from '/react/src/js/components/ToggleIcons';
+
+import {
+    CircleMinus, CirclePlus,
+    SquareMinus, SquarePlus,
+    ArrowRight, ArrowDown
+} from '/react/src/js/components/icons';
+
+describe('<ToggleIcons />', function () {
+
+    it('ExpandedIcon mount', function () {
+        
+        const wrapper = render(
+            <ExpandedIcon
+                theme='rjv-default'
+            />
+        );
+        expect(wrapper.find('.expanded-icon')).to.have.length(1);
+    });
+    
+    it('CollapsedIcon mount', function () {
+        
+        const wrapper = render(
+            <CollapsedIcon
+                theme='rjv-default'
+            />
+        );
+        expect(wrapper.find('.collapsed-icon')).to.have.length(1);
+    });
+
+    it('ExpandedIcon with triangle style', function() {
+        const wrapper = shallow(
+            <ExpandedIcon
+                theme='rjv-default'
+                iconStyle="triangle"
+            />
+        );
+        expect(wrapper.type()).to.equal(ArrowDown);
+    });
+    
+    it('ExpandedIcon with square style', function() {
+        const wrapper = shallow(
+            <ExpandedIcon
+                theme='rjv-default'
+                iconStyle="square"
+            />
+        );
+        expect(wrapper.type()).to.equal(SquareMinus);
+    });
+    
+    it('ExpandedIcon with no style', function() {
+        const wrapper = shallow(
+            <ExpandedIcon
+                theme='rjv-default'
+            />
+        );
+        expect(wrapper.type()).to.equal(CircleMinus);
+    });
+
+
+    it('CollapsedIcon with triangle style', function() {
+        const wrapper = shallow(
+            <CollapsedIcon
+                theme='rjv-default'
+                iconStyle="triangle"
+            />
+        );
+        expect(wrapper.type()).to.equal(ArrowRight);
+    });
+    
+    it('CollapsedIcon with square style', function() {
+        const wrapper = shallow(
+            <CollapsedIcon
+                theme='rjv-default'
+                iconStyle="square"
+            />
+        );
+        expect(wrapper.type()).to.equal(SquarePlus);
+    });
+    
+    it('CollapsedIcon with no style', function() {
+        const wrapper = shallow(
+            <CollapsedIcon
+                theme='rjv-default'
+            />
+        );
+        expect(wrapper.type()).to.equal(CirclePlus);
+    });
+})

--- a/test/tests/js/components/VariableMeta-test.js
+++ b/test/tests/js/components/VariableMeta-test.js
@@ -101,8 +101,9 @@ describe('<VariableMeta />', function () {
         ).to.have.length(1);
         expect(
             wrapper.find('.copy-icon')
-        ).to.have.length(2);
+        ).to.have.length(1);
 
+        document.execCommand = (mock) => {};
         wrapper.find('.copy-icon').first().simulate('click');
         //verify that callback was called
         expect(callback_counter).to.equal(1);
@@ -125,7 +126,7 @@ describe('<VariableMeta />', function () {
         ).to.have.length(1);
         expect(
             wrapper.find('.copy-icon')
-        ).to.have.length(2);
+        ).to.have.length(1);
 
         wrapper.find('.copy-icon').first().simulate('click');
     });


### PR DESCRIPTION
Hi there! 

I've been using this for a project of mine (fantastic work on this project, it's by far the best react based JSON prettifier I've found). My project deals with pretty large JSON datasets - especially arrays. I found that displaying 200+ array elements all at once was pretty slow to render, so I thought I would introduce a PR to group arrays by count, like so: 

![ko5nyju](https://user-images.githubusercontent.com/572055/33413075-e0b885b4-d554-11e7-9b2d-ef333e174e01.png)
![cvyiat2](https://user-images.githubusercontent.com/572055/33413076-e0c61ddc-d554-11e7-8e35-82fb7c22a18f.png)

The limit for the group size can be set with the component property `groupArraysAfterLength`. By default, this property is set to false and ignored.

I've coded the initial proof of concept and it appears to be working in the scenarios I've tested so far. You can take a look at it on the dev server at the very last example. 

Before I go further with testing, I wanted to send this over to you to take a look at the implementation and make sure you don't see any major issues with my approach. The major changes I made were:

- Added a new ArrayGroup component that renders the paginated array groups and handles their expanded state.
- Since there was a lot of functionality overlap between DataTypes/Object and ArrayGroup, I moved several methods from Object into their own functional component.

Let me know what you think. If/when it's ready to move forward, I am happy to continue testing and writing the unit tests and documentation to finish it off. 

Thanks for considering!