### PR TITLE
[Small-FIX] Changed devServer host to point to localhost from 0.0.0.0

### DIFF
--- a/webpack/webpack.config-dev.js
+++ b/webpack/webpack.config-dev.js
@@ -16,7 +16,7 @@ const config = {
     "react-dom": "ReactDOM"
   },
   devServer: {
-    host: "0.0.0.0",
+    host: "localhost",
     port: 2000,
     hot: true,
     inline: true,


### PR DESCRIPTION
Readme Mention to use localhost to run demo but 0.0.0.0 is defined in webpack-dev file. 
With the change in webpack it launches the app correctly with 'npm run dev'