### PR TITLE
sort object keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Name|Type|Default|Description
 `onAdd`|`(add)=>{}`|`false`|When a callback function is passed in, `add` functionality is enabled.  The callback is invoked before additions are completed. Returning `false` from `onAdd` will prevent the change from being made. [see: onAdd docs](#onedit-onadd-and-ondelete-interaction)
 `onDelete`|`(delete)=>{}`|`false`|When a callback function is passed in, `delete` functionality is enabled.  The callback is invoked before deletions are completed. Returning `false` from `onDelete` will prevent the change from being made. [see: onDelete docs](#onedit-onadd-and-ondelete-interaction)
 `onSelect`|`(select)=>{}`|`false`|When a function is passed in, clicking a value triggers the `onSelect` method to be called.
+`sortKeys`|`boolean`|set to true to sort object keys
 `validationMessage`|`string`|"Validation Error"|Custom message for validation failures to `onEdit`, `onAdd`, or `onDelete` callbacks
 
 ### Features

--- a/src/js/components/DataTypes/Object.js
+++ b/src/js/components/DataTypes/Object.js
@@ -224,15 +224,18 @@ class rjvObject extends React.Component {
         let theme = props.theme
         let elements = [],
             variable
-
-        for (let name in variables) {
+        let keys = Object.keys(variables || {});
+        if (this.props.sortKeys) {
+            keys = keys.sort();
+        }
+        keys.forEach(name => {
             variable = new JsonVariable(name, variables[name])
 
             if (parent_type == "array_group" && index_offset) {
                 variable.name = parseInt(variable.name) + index_offset
             }
             if (!variables.hasOwnProperty(name)) {
-                continue
+                return
             } else if (variable.type == "object") {
                 elements.push(
                     <JsonObject
@@ -279,7 +282,7 @@ class rjvObject extends React.Component {
                     />
                 )
             }
-        }
+        })
         return elements
     }
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -42,6 +42,7 @@ export default class extends React.Component {
         collapsed: false,
         collapseStringsAfterLength: false,
         shouldCollapse: false,
+        sortKeys: false,
         groupArraysAfterLength: 100,
         indentWidth: 4,
         enableClipboard: true,

--- a/test/tests/js/components/DataTypes/Object-test.js
+++ b/test/tests/js/components/DataTypes/Object-test.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { shallow, render } from "enzyme"
+import { shallow, render, mount } from "enzyme"
 import { expect } from "chai"
 
 import JsonObject from "./../../../../../src/js/components/DataTypes/Object"
@@ -324,5 +324,45 @@ describe("<JsonObject />", function() {
         )
 
         expect(wrapper.state("expanded")).to.equal(true)
+    })
+    it("sort object keys", () => {
+        let src = {
+            d: 'd',
+            b: 'b',
+            a: 'a',
+            c: 'c',
+         }
+
+        const wrapper = render(
+            <JsonObject
+                src={src}
+                theme="rjv-default"
+                namespace={["root"]}
+                sortKeys={true}
+                collapsed={false}
+                shouldCollapse={() => false}
+            />
+        )
+        expect(wrapper.text()).to.equal('"":{"a":"a""b":"b""c":"c""d":"d"}');
+    })
+
+    it("do not sort object keys", () => {
+        let src = {
+            d: 'd',
+            b: 'b',
+            a: 'a',
+            c: 'c',
+         }
+
+        const wrapper = render(
+            <JsonObject
+                src={src}
+                theme="rjv-default"
+                namespace={["root"]}
+                collapsed={false}
+                shouldCollapse={() => false}
+            />
+        )
+        expect(wrapper.text()).to.equal('"":{"d":"d""b":"b""a":"a""c":"c"}');
     })
 })


### PR DESCRIPTION
sometimes its nice to be able to tell the renderer that we want the keys sorted. 
This PR adds a prop `sortKeys` that will sort object keys alphabetically.