### PR TITLE
Empty Validation Message Bug

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -74,7 +74,7 @@ class ReactJsonView extends React.PureComponent {
                 validationMessage: nextProps.validationMessage,
                 prevSrc: nextProps.src,
                 prevName: nextProps.name,
-                prevTheme: nextProps.theme,
+                prevTheme: nextProps.theme
             };
             return ReactJsonView.validateState(newPartialState);
         }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -25,6 +25,7 @@ class ReactJsonView extends React.PureComponent {
             src: ReactJsonView.defaultProps.src,
             name: ReactJsonView.defaultProps.name,
             theme: ReactJsonView.defaultProps.theme,
+            validationMessage: ReactJsonView.defaultProps.validationMessage,
             // the state object also needs to remember the prev prop values, because we need to compare
             // old and new props in getDerivedStateFromProps().
             prevSrc: ReactJsonView.defaultProps.src,
@@ -70,9 +71,10 @@ class ReactJsonView extends React.PureComponent {
                 src: nextProps.src,
                 name: nextProps.name,
                 theme: nextProps.theme,
+                validationMessage: nextProps.validationMessage,
                 prevSrc: nextProps.src,
                 prevName: nextProps.name,
-                prevTheme: nextProps.theme
+                prevTheme: nextProps.theme,
             };
             return ReactJsonView.validateState(newPartialState);
         }


### PR DESCRIPTION
`ValidationFailure` fails to display default or custom messages.

### Screenshot

Following is the screenshot from the dev-server

<img width="1888" alt="screen shot 2018-07-02 at 8 44 50 pm" src="https://user-images.githubusercontent.com/8539605/42192755-ce634f92-7e38-11e8-92a1-7d0185be6619.png">

### Steps to reproduce

```
Run the Dev Server
# clone this repository
git clone git@github.com:mac-s-g/react-json-view.git && cd react-json-view
# install dependencies
npm install --save-dev
# run the dev server with hot reloading
npm run dev

Edit any field to 'error'
```

### Environment
```
npm -v 5.6.0
node -v v9.8.0
react -v 16.4.1
Browser: Chrome: Version 67.0.3396.99 (Official Build) (64-bit)
```

### Fix

Seems like `validationMessage` state wasn't initialized.