### PR TITLE
Add a way to set the default value when adding a key to json

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Name|Type|Default|Description
 `displayDataTypes`|`boolean`|`true`|When set to `true`, data type labels prefix values
 `onEdit`|`(edit)=>{}`|`false`|When a callback function is passed in, `edit` functionality is enabled.  The callback is invoked before edits are completed. Returning `false` from `onEdit` will prevent the change from being made. [see: onEdit docs](#onedit-onadd-and-ondelete-interaction)
 `onAdd`|`(add)=>{}`|`false`|When a callback function is passed in, `add` functionality is enabled.  The callback is invoked before additions are completed. Returning `false` from `onAdd` will prevent the change from being made. [see: onAdd docs](#onedit-onadd-and-ondelete-interaction)
-`defaultValue`|`string | number | boolean | array | object`|`null`|Sets the default value to be used when adding an item to json
+`defaultValue`|`string \|number \|boolean \|array \|object`|`null`|Sets the default value to be used when adding an item to json
 `onDelete`|`(delete)=>{}`|`false`|When a callback function is passed in, `delete` functionality is enabled.  The callback is invoked before deletions are completed. Returning `false` from `onDelete` will prevent the change from being made. [see: onDelete docs](#onedit-onadd-and-ondelete-interaction)
 `onSelect`|`(select)=>{}`|`false`|When a function is passed in, clicking a value triggers the `onSelect` method to be called.
 `sortKeys`|`boolean`|`false`|set to true to sort object keys

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Name|Type|Default|Description
 `displayDataTypes`|`boolean`|`true`|When set to `true`, data type labels prefix values
 `onEdit`|`(edit)=>{}`|`false`|When a callback function is passed in, `edit` functionality is enabled.  The callback is invoked before edits are completed. Returning `false` from `onEdit` will prevent the change from being made. [see: onEdit docs](#onedit-onadd-and-ondelete-interaction)
 `onAdd`|`(add)=>{}`|`false`|When a callback function is passed in, `add` functionality is enabled.  The callback is invoked before additions are completed. Returning `false` from `onAdd` will prevent the change from being made. [see: onAdd docs](#onedit-onadd-and-ondelete-interaction)
+`defaultValue`|`string | number | boolean | array | object`|`null`|Sets the default value to be used when adding an item to json
 `onDelete`|`(delete)=>{}`|`false`|When a callback function is passed in, `delete` functionality is enabled.  The callback is invoked before deletions are completed. Returning `false` from `onDelete` will prevent the change from being made. [see: onDelete docs](#onedit-onadd-and-ondelete-interaction)
 `onSelect`|`(select)=>{}`|`false`|When a function is passed in, clicking a value triggers the `onSelect` method to be called.
 `sortKeys`|`boolean`|`false`|set to true to sort object keys

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/react-json-view.svg)](https://www.npmjs.com/package/react-json-view) [![npm](https://img.shields.io/npm/l/react-json-view.svg)](https://github.com/mac-s-g/react-json-view/blob/master/LISCENSE) [![Build Status](https://travis-ci.org/mac-s-g/react-json-view.svg)](https://travis-ci.org/mac-s-g/react-json-view) [![Coverage Status](https://coveralls.io/repos/github/mac-s-g/react-json-view/badge.svg?branch=master)](https://coveralls.io/github/mac-s-g/react-json-view?branch=master)
 
 # react-json-view
-RJV is a react component for displaying and editing javascript **arrays** and **JSON objects**.
+RJV is a React component for displaying and editing javascript **arrays** and **JSON objects**.
 
 This component provides a responsive interface for displaying arrays or JSON in a web browser.  NPM offers a distribution of the source that's transpiled to ES5; so you can include this component with *any web-based javascript application*.
 

--- a/dev-server/src/index.js
+++ b/dev-server/src/index.js
@@ -50,7 +50,7 @@ ReactDom.render(
                 }
                 return false
             }}
-            defaultValue=''
+            defaultValue=""
         />
 
         <br />

--- a/dev-server/src/index.js
+++ b/dev-server/src/index.js
@@ -50,6 +50,7 @@ ReactDom.render(
                 }
                 return false
             }}
+            defaultValue=''
         />
 
         <br />

--- a/index.d.ts
+++ b/index.d.ts
@@ -129,6 +129,12 @@ export interface ReactJsonViewProps {
    * Default: false
    */
   sortKeys?: boolean;
+  /**
+   * Set to a value to be used as defaultValue when adding new key to json
+   *
+   * Default: null
+   */
+  defaultValue?: string | number | boolean | null | undefined | string[] | number[] | boolean[] | {}[] | {};
 }
 
 export interface OnCopyProps {

--- a/index.d.ts
+++ b/index.d.ts
@@ -134,7 +134,7 @@ export interface ReactJsonViewProps {
    *
    * Default: null
    */
-  defaultValue?: string | number | boolean | null | undefined | string[] | number[] | boolean[] | {}[] | {};
+  defaultValue?: TypeDefaultValue | TypeDefaultValue[] | null;
 }
 
 export interface OnCopyProps {
@@ -218,6 +218,8 @@ export interface OnSelectProps {
   namespace: Array<string | null>;
 
 }
+
+export type TypeDefaultValue = string | number | boolean | object;
 
 export interface ThemeObject {
   base00: string;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-json-view",
     "description": "Interactive react component for displaying javascript arrays and JSON objects.",
-    "version": "1.18.2",
+    "version": "1.19.0",
     "main": "dist/main.js",
     "dependencies": {
         "flux": "^3.1.3",

--- a/src/js/components/ObjectKeyModal/AddKeyRequest.js
+++ b/src/js/components/ObjectKeyModal/AddKeyRequest.js
@@ -40,7 +40,7 @@ export default class extends React.PureComponent {
             rjvId, 'action', 'new-key-request'
         );
         request.new_value = {...request.existing_value};
-        request.new_value[input] = null;
+        request.new_value[input] = this.props.defaultValue;
         dispatcher.dispatch({
             name: 'VARIABLE_ADDED',
             rjvId: rjvId,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -56,7 +56,8 @@ class ReactJsonView extends React.PureComponent {
         onSelect: false,
         iconStyle: 'triangle',
         style: {},
-        validationMessage: 'Validation Error'
+        validationMessage: 'Validation Error',
+        defaultValue: null,
     }
 
     // will trigger whenever setState() is called, or parent passes in new props.
@@ -176,7 +177,7 @@ class ReactJsonView extends React.PureComponent {
             name
         } = this.state;
 
-        const { style } = this.props;
+        const { style, defaultValue } = this.props;
 
         return (
             <div
@@ -198,7 +199,8 @@ class ReactJsonView extends React.PureComponent {
                 <AddKeyRequest
                     active={addKeyRequest}
                     theme={theme}
-                    rjvId={this.rjvId} />
+                    rjvId={this.rjvId}
+                    defaultValue={defaultValue} />
             </div>
         );
     }


### PR DESCRIPTION
The current behaviour when adding a new key to JSON is to set its value to null. I needed it to be empty string, and I thought other people could benefit to setting the default value to something else. 
For instance if you have a JSON with booleans, you could default new entries to true or false.
The code added is little intrusive to the whole system.
I wasn't sure what testing I could add for it, and I'm happy to make one if given directions.
Also the name of the prop `defaultValue` might be too 'wide' for what it does, any naming suggestions appreciated.