### PR TITLE
set default style with min-height & word-bread

### DIFF
--- a/src/style/scss/global.scss
+++ b/src/style/scss/global.scss
@@ -1,4 +1,8 @@
 .react-json-view {
+    min-height: 96px;
+    word-break: break-all;
+    -ms-word-break: break-all;
+
     .copy-to-clipboard-container {
         vertical-align: top;
         display: none;


### PR DESCRIPTION
@mac-s-g Many thanks for this great project. We are successfully using it in production. However, we have identified 2 minor bugs :
- the AddKeyRequest component is masked when the initial JSON is empty and there is another ReactJson component below. So, a good compromise could be to set a min-height on the react-json-view container
- when the value of a key is too long, after a click on it, it displays beyond the container. So, a good fix would be to use the [word-break CSS property](https://css-tricks.com/almanac/properties/w/word-break/)