### PR TITLE
Fix bug with small floats and add support for scientific notation

### DIFF
--- a/src/js/helpers/parseInput.js
+++ b/src/js/helpers/parseInput.js
@@ -19,14 +19,26 @@ export default function parseInput(input) {
             input.match(/\-?\d+\.\d+/)
             && input.match(/\-?\d+\.\d+/)[0] === input
         ) {
-            //integer
+            //float
             return formatResponse('float', parseFloat(input));
+        } else if (
+            input.match(/\-?\d+e-\d+/)
+            && input.match(/\-?\d+e-\d+/)[0] === input
+        ) {
+            //scientific float
+            return formatResponse('float', Number(input));
         } else if (
             input.match(/\-?\d+/)
             && input.match(/\-?\d+/)[0] === input
         ) {
-            //float
+            //integer
             return formatResponse('integer', parseInt(input));
+        } else if (
+            input.match(/\-?\d+e\+\d+/)
+            && input.match(/\-?\d+e\+\d+/)[0] === input
+        ) {
+            //scientific integer
+            return formatResponse('integer', Number(input));
         }
     } catch (e) {
         // no-op

--- a/test/tests/js/helpers/parseInput-test.js
+++ b/test/tests/js/helpers/parseInput-test.js
@@ -20,12 +20,24 @@ describe("parseInput", function() {
         expect(parseInput("5.22").type).to.equal("float")
     })
 
+    it("parseInput small float", function() {
+        expect(parseInput("0.0000002").type).to.equal("float")
+    })
+
+    it("parseInput scientific notation float", function() {
+        expect(parseInput("2e-7").type).to.equal("float")
+    })
+
     it("parseInput date", function() {
         expect(parseInput("5/22").type).to.equal("date")
     })
 
     it("parseInput integer", function() {
         expect(parseInput("22").type).to.equal("integer")
+    })
+
+    it("parseInput scientific notation integer", function() {
+        expect(parseInput("4e+8").type).to.equal("integer")
     })
 
     it("parseInput NaN", function() {


### PR DESCRIPTION
This fixes a bug where small floats (eg. `0.0000002`) would not be detected as floats due to `JSON.parse` converting them to scientific notation (`2e-7`).