### PR TITLE
Allow peer dependency of React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
         "webpack-dev-server": "^2.11.2"
     },
     "peerDependencies": {
-        "react": "^16.0.0 || ^15.5.4",
-        "react-dom": "^16.0.0 || ^15.5.4"
+        "react": "^17.0.0 || ^16.0.0 || ^15.5.4",
+        "react-dom": "^17.0.0 || ^16.0.0 || ^15.5.4"
     },
     "scripts": {
         "build":


### PR DESCRIPTION
Ran this with React 17 and got this error. I forced it and it tested fine on my machine. 

```npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: react-demo@0.1.0
npm ERR! Found: react@17.0.1
npm ERR! node_modules/react
npm ERR!   react@"^17.0.1" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.0.0 || ^15.5.4" from react-json-view@1.19.1
npm ERR! node_modules/react-json-view
npm ERR!   react-json-view@"*" from the root project
```
