### PR TITLE
remove coverage info from production build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,13 @@
   "plugins": [
     "@babel/plugin-syntax-class-properties",
     "@babel/plugin-syntax-jsx",
-    "react-html-attrs",
-    "istanbul"
-  ]
+    "react-html-attrs"
+  ],
+  "env": {
+    "test": {
+      "plugins": [
+        "istanbul"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-json-view",
     "description": "Interactive react component for displaying javascript arrays and JSON objects.",
-    "version": "1.20.2",
+    "version": "1.20.3",
     "main": "dist/main.js",
     "dependencies": {
         "flux": "^4.0.1",


### PR DESCRIPTION
istanbul should only be included as a plugin when `NODE_ENV=test`