### PR TITLE
Don't sort keys if the object is an array.

### DIFF
--- a/src/js/components/DataTypes/Object.js
+++ b/src/js/components/DataTypes/Object.js
@@ -249,7 +249,7 @@ class RjvObject extends React.PureComponent {
         let elements = [],
             variable;
         let keys = Object.keys(variables || {});
-        if (this.props.sortKeys) {
+        if (this.props.sortKeys && object_type !== 'array') {
             keys = keys.sort();
         }
 


### PR DESCRIPTION
Just a refresh of this PR based on latest master: https://github.com/mac-s-g/react-json-view/pull/263

Change originally by @clangen-nw

cc: @mac-s-g (I don't seem to be able to assign reviewers)