### PR TITLE
Fix display issue for objects with length property

### DIFF
--- a/src/js/components/JsonViewer.js
+++ b/src/js/components/JsonViewer.js
@@ -8,9 +8,10 @@ export default class extends React.PureComponent {
         const namespace = [props.name];
         let ObjectComponent = JsonObject;
 
+        const size = Array.isArray(props.src) ? props.src.length: Object.keys(props.src).length;
         if (
             props.groupArraysAfterLength &&
-            props.src.length > props.groupArraysAfterLength
+            size > props.groupArraysAfterLength
         ) {
             ObjectComponent = ArrayGroup;
         }

--- a/src/js/components/JsonViewer.js
+++ b/src/js/components/JsonViewer.js
@@ -8,7 +8,9 @@ export default class extends React.PureComponent {
         const namespace = [props.name];
         let ObjectComponent = JsonObject;
 
-        const size = Array.isArray(props.src) ? props.src.length: Object.keys(props.src).length;
+        const size = Array.isArray(props.src)
+            ? props.src.length
+            : Object.keys(props.src).length;
         if (
             props.groupArraysAfterLength &&
             size > props.groupArraysAfterLength

--- a/test/tests/js/Index-test.js
+++ b/test/tests/js/Index-test.js
@@ -117,4 +117,17 @@ describe("<Index />", function() {
         )
         expect(wrapper.find(".array-group")).to.have.length(3)
     })
+
+    it("length is correct even if an object has a length property", function () {
+        const wrapper = render(
+            <Index
+                src={{
+                    first: "first property",
+                    second: "second property",
+                    length: 1000
+                }}
+            />
+        )
+        expect(wrapper.find(".object-size")).to.have.length(1)
+    })
 })


### PR DESCRIPTION
Hi @mac-s-g,
This pull request covers the issue #252 where the 'length' property is misinterpreted as the length of an array.
Best,