### PR TITLE
Fix "Invalid array length" error

### DIFF
--- a/src/js/components/JsonViewer.js
+++ b/src/js/components/JsonViewer.js
@@ -8,12 +8,10 @@ export default class extends React.PureComponent {
         const namespace = [props.name];
         let ObjectComponent = JsonObject;
 
-        const size = Array.isArray(props.src)
-            ? props.src.length
-            : Object.keys(props.src).length;
         if (
+            Array.isArray(props.src) &&
             props.groupArraysAfterLength &&
-            size > props.groupArraysAfterLength
+            props.src.length > props.groupArraysAfterLength
         ) {
             ObjectComponent = ArrayGroup;
         }


### PR DESCRIPTION
If an object has more keys than `groupArraysAfterLength`, then it will be rendered as an Array due to the changes in #336

Fix this logic so only arrays are rendered as arrays.

Fixes #340