### PR TITLE
fix: missing displayArrayKey props in TS typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -141,6 +141,12 @@ export interface ReactJsonViewProps {
    * Default: null
    */
   defaultValue?: TypeDefaultValue | TypeDefaultValue[] | null;
+  /**
+   * When set to true, the index of the elements prefix values
+   *
+   * Default: true
+   */
+  displayArrayKey?: boolean;
 }
 
 export interface OnCopyProps {


### PR DESCRIPTION
Small fix for missing displayArrayKey property in TypeScript typings, as specified in README.