### PR TITLE
fix: missing displayArrayKey prop in TS typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,12 @@ export interface ReactJsonViewProps {
    */
   displayDataTypes?: boolean;
   /**
+   * When set to true, the index of the elements prefix values.
+   *
+   * Default: true
+   */
+  displayArrayKey?: boolean;
+  /**
    * set to false to remove quotes from keys (eg. "name": vs. name:)
    *
    * Default: true


### PR DESCRIPTION
I noticed that this prop was missing from the TS typings, so I added it. Thank you for this great component! 👍