### PR TITLE
fix(#347): change inputRef to ref to prevent runtime error

### DIFF
--- a/src/js/components/VariableEditor.js
+++ b/src/js/components/VariableEditor.js
@@ -260,7 +260,7 @@ class VariableEditor extends React.PureComponent {
             <div>
                 <AutosizeTextarea
                     type="text"
-                    inputRef={input => input && input.focus()}
+                    ref={input => input && input.focus()}
                     value={editValue}
                     class="variable-editor"
                     onChange={event => {


### PR DESCRIPTION
## Motivation
  
When editing (focusing) an attribute value, VariableEditor causes react_devtools_backend to throw a runtime error due to usage of unrecognized attribute `inputRef` (instead of `ref`) in AutosizeTextarea component.

```
Warning: React does not recognize the `inputRef` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `inputref` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

AutosizeTextarea [docs](https://github.com/Andarist/react-textarea-autosize#how-to-focus)
related issue: https://github.com/mac-s-g/react-json-view/issues/347