### PR TITLE
Add onSelect event to object keys

### DIFF
--- a/src/js/components/ObjectName.js
+++ b/src/js/components/ObjectName.js
@@ -9,7 +9,8 @@ export default function getObjectName(props) {
         theme,
         jsvRoot,
         name,
-        displayArrayKey
+        displayArrayKey,
+        onSelect
     } = props;
 
     const display_name = props.name ? props.name : '';
@@ -28,7 +29,21 @@ export default function getObjectName(props) {
     } else {
         return (
             <span {...Theme(theme, 'object-name')} key={namespace}>
-                <span class="object-key">
+                <span
+                    onClick={
+                        onSelect === false
+                            ? null
+                            : e => {
+                                  let location = [...namespace];
+                                  location.shift();
+                                  onSelect({
+                                      isKey: true,
+                                      key: display_name,
+                                      namespace: location
+                                  });
+                              }
+                    }
+                    class="object-key">
                     {quotesOnKeys && (
                         <span style={{ verticalAlign: 'top' }}>"</span>
                     )}

--- a/src/js/components/VariableEditor.js
+++ b/src/js/components/VariableEditor.js
@@ -86,6 +86,19 @@ class VariableEditor extends React.PureComponent {
                     <span>
                         <span
                             {...Theme(theme, 'object-name')}
+                            onClick={
+                                onSelect === false
+                                    ? null
+                                    : e => {
+                                          let location = [...namespace];
+                                          location.shift();
+                                          onSelect({
+                                              isKey: true,
+                                              key: variable.name,
+                                              namespace: location
+                                          });
+                                      }
+                            }
                             class="object-key"
                             key={variable.name + '_' + namespace}
                         >


### PR DESCRIPTION
Hey @mac-s-g! I created this tiny PR to add `onSelect` to object keys as well. In a project I'm working on we need the keys to trigger the `onSelect` event and I thought of creating a PR instead of just forking.

Would you be able to merge it in?